### PR TITLE
Fix platform mismatch and git permissions in CI/CD workflows

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -166,6 +166,7 @@ jobs:
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
           script: |
+            sudo chown -R $USER:$USER /opt/finpath
             cd /opt/finpath
             git config --global --add safe.directory /opt/finpath
             git pull origin dev

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -84,7 +84,7 @@ jobs:
           context: ./apps/finpath-backend
           file: ./apps/finpath-backend/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/arm64
           tags: ${{ steps.meta_backend.outputs.tags }}
           labels: ${{ steps.meta_backend.outputs.labels }}
           cache-from: type=gha,scope=backend-prod
@@ -140,7 +140,7 @@ jobs:
           context: ./apps/finpath-frontend-web
           file: ./apps/finpath-frontend-web/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/arm64
           tags: ${{ steps.meta_web.outputs.tags }}
           labels: ${{ steps.meta_web.outputs.labels }}
           cache-from: type=gha,scope=frontend-web-prod
@@ -166,6 +166,7 @@ jobs:
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
           script: |
+            sudo chown -R $USER:$USER /opt/finpath
             cd /opt/finpath
             git config --global --add safe.directory /opt/finpath
             git pull origin prod


### PR DESCRIPTION
- Change prod workflow platform from linux/amd64 to linux/arm64 (Hetzner server is ARM64)
- Add sudo chown to fix git permission errors during deployment
- Ensures deployment user has proper ownership of /opt/finpath directory

Fixes:
- "no matching manifest for linux/arm64/v8" error
- "cannot open '.git/FETCH_HEAD': Permission denied" error