### PR TITLE
Fix docker-compose syntax and git permission errors

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -166,10 +166,10 @@ jobs:
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
           script: |
-            sudo chown -R $USER:$USER /opt/finpath
             cd /opt/finpath
             git config --global --add safe.directory /opt/finpath
-            git pull origin dev
+            git fetch origin dev
+            git reset --hard origin/dev
             cd ops
             docker compose -f docker-compose.dev.yml pull
             docker compose -f docker-compose.dev.yml up -d

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -166,10 +166,10 @@ jobs:
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
           script: |
-            sudo chown -R $USER:$USER /opt/finpath
             cd /opt/finpath
             git config --global --add safe.directory /opt/finpath
-            git pull origin prod
+            git fetch origin prod
+            git reset --hard origin/prod
             cd ops
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml up -d

--- a/ops/docker-compose.prod.yml
+++ b/ops/docker-compose.prod.yml
@@ -25,7 +25,7 @@ services:
       # JVM Options for production
       JAVA_OPTS: "-Xmx512m -Xms256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
     expose:
-      - "9080:9080"
+      - "9080"
     networks:
       - finpath-net
     restart: always


### PR DESCRIPTION
- Fix invalid port syntax in docker-compose.prod.yml (expose should not have port mappings)
- Remove sudo from deployment scripts (user doesn't have passwordless sudo)
- Replace git pull with fetch + reset --hard to avoid FETCH_HEAD permission errors
- Ensures clean deployment without permission issues

Fixes:
- "invalid port '9080:9080': invalid syntax" error
- "sudo: a password is required" error
- "cannot open '.git/FETCH_HEAD': Permission denied" error